### PR TITLE
Panel styles

### DIFF
--- a/components/Panel/Panel.css
+++ b/components/Panel/Panel.css
@@ -4,3 +4,18 @@
   background: var(--color-white);
   box-shadow: 1px 1px 1px rgba(0,0,0,0.1);
 }
+
+.success {
+  background: color(var(--color-green) l(+ 5%));
+  color: var(--color-white);
+}
+
+.error {
+  background: color(var(--color-red) l(+ 5%));
+  color: var(--color-white);
+}
+
+.info {
+  background: color(var(--color-blue) l(+ 5%));
+  color: var(--color-white);
+}

--- a/components/Panel/Panel.css
+++ b/components/Panel/Panel.css
@@ -16,6 +16,6 @@
 }
 
 .info {
-  background: color(var(--color-blue) l(+ 5%));
+  background: color(var(--color-blue-dark) l(+ 5%));
   color: var(--color-white);
 }

--- a/components/Panel/Panel.js
+++ b/components/Panel/Panel.js
@@ -2,10 +2,22 @@ import React, {Component, PropTypes} from 'react';
 
 import styles from './Panel.css';
 
+
+const types = {
+  info: styles.info,
+  success: styles.success,
+  error: styles.error
+};
+
 export default class Panel extends Component {
   render() {
+    const classNames = [
+      styles.root,
+      types[this.props.type]
+    ].join(' ');
+
     return (
-      <div className={styles.root}>
+      <div className={classNames}>
         {this.props.children}
       </div>
     );
@@ -13,5 +25,6 @@ export default class Panel extends Component {
 }
 
 Panel.propTypes = {
-  children: PropTypes.any
+  children: PropTypes.any,
+  type: PropTypes.string
 };

--- a/globals/colours.css
+++ b/globals/colours.css
@@ -10,6 +10,7 @@
   --color-brown:        rgb(156,120,102);
   --color-brown-dark:   rgb(96,79,76);
   --color-blue:         rgb(41,179,225);
+  --color-blue-dark:    rgb(128,176,211);
 
   --color-primary:   var(--color-green);
   --color-secondary: var(--color-orange);

--- a/globals/colours.css
+++ b/globals/colours.css
@@ -9,6 +9,7 @@
   --color-grey-lighter: rgb(197,197,197);
   --color-brown:        rgb(156,120,102);
   --color-brown-dark:   rgb(96,79,76);
+  --color-blue:         rgb(41,179,225);
 
   --color-primary:   var(--color-green);
   --color-secondary: var(--color-orange);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loggins",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Pact's component library",
   "main": "components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loggins",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Pact's component library",
   "main": "components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loggins",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "Pact's component library",
   "main": "components/index.js",
   "scripts": {

--- a/styleguide/sections/Panels.js
+++ b/styleguide/sections/Panels.js
@@ -44,7 +44,29 @@ export default class Panels extends Component {
               </List>
             </Panel>
           </div>
+        </div>
 
+        <div className={[styles.grid, m.mtm].join(' ')}>
+
+          <div className={styles.half}>
+            <Panel type="error">
+              What the hell did you do!?!
+            </Panel>
+          </div>
+
+          <div className={styles.half}>
+            <Panel type="info">
+              Oh so informative am I.
+            </Panel>
+          </div>
+        </div>
+
+        <div className={[styles.grid, m.mtm].join(' ')}>
+          <div className={styles.half}>
+            <Panel type="success">
+              You gone done good, didn't you.
+            </Panel>
+          </div>
         </div>
       </Section>
     );


### PR DESCRIPTION
This adds the ability to use panels as notification banners. 

Currently supports:
Info - blue (blue needs updating to be more Pacty. Suggestions welcome)
Success - green
Error - red

<img width="965" alt="screen shot 2015-07-06 at 12 40 38" src="https://cloud.githubusercontent.com/assets/7048758/8521512/40fe22bc-23dc-11e5-80da-6e26529eeab1.png">
