### PR TITLE
HashHistory

### DIFF
--- a/styleguide/index.js
+++ b/styleguide/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Router} from 'react-router';
-import {history} from 'react-router/lib/BrowserHistory';
+import {history} from 'react-router/lib/HashHistory';
 
 import routes from './routes';
 


### PR DESCRIPTION
As we're static-serving `index.html`, the html5 history API won't work.
So we use hash history instead, which does work.