### PR TITLE
Fix build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,7 @@
 {
-  "extends": "airbnb"
+  "extends": "airbnb",
+  "rules": {
+    "id-length": 0,
+    "react/no-did-mount-set-state": 0,
+  },
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "npm run build && cd styleguide && node server.js",
     "clean": "cd styleguide && rimraf public",
     "test": "eslint ./components && karma start --single-run",
-    "prepublish": "npm test"
+    "preversion": "npm test"
   },
   "repository": {
     "type": "git",

--- a/styleguide/.babelrc
+++ b/styleguide/.babelrc
@@ -1,5 +1,5 @@
 {
-  "stage": 0,
+  "stage": 1,
   "env": {
     "development": {
       "plugins": ["react-transform"],

--- a/styleguide/Styleguide.js
+++ b/styleguide/Styleguide.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import {uniqueId} from 'lodash';
 import {TransitionMotion, spring} from 'react-motion';
 
 import Logo from 'components/Logo/Logo';
@@ -65,7 +66,7 @@ export default class Styleguide extends React.Component {
   getStyles() {
     const {children} = this.props;
     return {
-      [children.type.displayName]: {
+      [uniqueId('animator')]: {
         opacity: spring(1),
         x: spring(0, physics),
         child: children,

--- a/styleguide/Styleguide.js
+++ b/styleguide/Styleguide.js
@@ -13,8 +13,8 @@ const ROUTES = [
   'grids',
   'blocks',
   'buttons',
-  'forms',
   'overlays',
+  'forms',
   'panels',
   'icons',
 ];

--- a/styleguide/index.js
+++ b/styleguide/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {Router} from 'react-router';
-import createBrowserHistory from 'history/lib/createBrowserHistory';
+import {createHashHistory} from 'history';
 
 import routes from './routes';
 
 React.render(
   <Router
-    history={createBrowserHistory()}
+    history={createHashHistory()}
     children={routes}
   />,
   document.getElementById('outlet'));


### PR DESCRIPTION
Prepublish does not _only_ run before publishing — it will also run as part of a standard `npm install` under certain circumstances.
See [this article](https://medium.com/greenkeeper-blog/what-is-npm-s-prepublish-and-why-is-it-so-confusing-a948373e6be1) for details.

So we now run `npm test` as part of `preversion`.