### PR TITLE
Generic radio group with default styles

### DIFF
--- a/components/MaskedFormInput/MaskedFormInput.js
+++ b/components/MaskedFormInput/MaskedFormInput.js
@@ -84,7 +84,6 @@ export default class MaskedFormInput extends Component {
 }
 
 MaskedFormInput.propTypes = {
-
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,

--- a/components/RadioGroup/Radio.css
+++ b/components/RadioGroup/Radio.css
@@ -5,12 +5,12 @@
 .group {
   position: relative;
 }
-.child {
+.radio {
   position: relative;
 }
 
 /* Radio */
-.radio {
+.radio input {
   opacity: 0;
   position: absolute;
   top: 0.15em;
@@ -19,7 +19,7 @@
   height: var(--baseRadioSize);
 }
 
-.radioLabel {
+.radio label {
   cursor: pointer;
   user-select: none;
   position: relative;
@@ -28,15 +28,15 @@
   transition: all 200ms var(--easeinoutback);
   padding-left: calc(var(--baseRadioSize) + 0.5em);
 }
-.radioLabel:hover {
+.radio label:hover {
   color: var(--color-primary);
 }
-.radioLabel:hover:before {
+.radio label:hover:before {
   border-color: var(--color-primary);
 }
 
 /* Outer ring */
-.radioLabel:before {
+.radio label:before {
   position: absolute;
   left: 0;
   top: 0.15em;
@@ -52,7 +52,7 @@
 }
 
 /* Inner circle */
-.radioLabel:after {
+.radio label:after {
   content: '';
   position: absolute;
   left: 0;
@@ -68,58 +68,10 @@
   opacity: 0;
 }
 
-.radio:checked + .radioLabel:before {
+.radio input:checked + label:before {
   border-color: var(--color-primary);
 }
-.radio:checked + .radioLabel:after {
+.radio input:checked + label:after {
   transform: scale(0.75);
   opacity: 1;
-}
-
-/* Giant variant */
-.giant {
-  display: table;
-  width: 100%;
-  text-align: center;
-}
-.giant .radio {
-  display: none;
-}
-.giant .child {
-  display: table-cell;
-  text-align: center;
-  margin: 0 0.5em;
-  width: 1%;
-}
-.giant .radioLabel {
-  color: var(--color-grey-light);
-  transition: none;
-  display: block;
-  padding: 0;
-}
-.giant .radioLabel:before,
-.giant .radioLabel:after {
-  display: none;
-}
-.giant .iconOuter {
-  display: block;
-}
-.giant .iconInner {
-  box-shadow: inset 0 0 0 2px var(--color-grey-light);
-  margin: 0 auto 0.5em;
-  border-radius: 50%;
-  padding: 0.75em;
-  display: inline-block;
-}
-.giant .icon {
-  font-size: 3em;
-}
-
-.giant .radio:checked + .radioLabel {
-  color: var(--color-primary);
-}
-.giant .radio:checked + .radioLabel .iconInner {
-  background: var(--color-primary);
-  color: var(--color-white);
-  box-shadow: none;
 }

--- a/components/RadioGroup/Radio.js
+++ b/components/RadioGroup/Radio.js
@@ -1,34 +1,15 @@
 import React, {PropTypes} from 'react';
 import {uniqueId} from 'lodash';
 
-import * as m from '../../globals/modifiers.css';
-import Icon from '../Icon/Icon';
-import s from './Radio.css';
+import css from './Radio.css';
 
 export default class Radio {
   constructor() {
-    this.renderValue = this.renderValue.bind(this);
     this.state = {
       id: uniqueId('radio'),
     };
   }
-  renderValue() {
-    const {giant, icon, children, value} = this.props;
-    if (giant) {
-      return (
-        <span className={s.iconOuter}>
-          <span className={s.iconInner}>
-            <Icon className={s.icon} name={icon || 'tick'}/>
-          </span>
-          <span className={m.db}>{value}</span>
-        </span>
-      );
-    }
-    if (children) {
-      return children;
-    }
-    return value;
-  }
+
   render() {
     const {
       name,
@@ -36,21 +17,22 @@ export default class Radio {
       onChange,
       className,
       selectedValue,
+      children
     } = this.props;
     const {id} = this.state;
     const isChecked = value === selectedValue;
     return (
-      <span className={[s.child, className].join(' ')}>
+      <span className={[css.radio, className].join(' ')}>
         <input id={id}
                type="radio"
-               className={s.radio}
                checked={isChecked}
                name={name}
                value={value}
                onChange={() => onChange(this.props.value)} />
-        <label htmlFor={id}
-               className={s.radioLabel}>
-          {this.renderValue()}
+        <label htmlFor={id}>
+          {children ? (
+            {children}
+          ) : {value}}
         </label>
       </span>
     );
@@ -75,7 +57,4 @@ Radio.propTypes = {
 
   className: PropTypes.string,
   children: PropTypes.any,
-
-  giant: PropTypes.bool,
-  icon: PropTypes.string,
 };

--- a/components/RadioGroup/RadioGroup.js
+++ b/components/RadioGroup/RadioGroup.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 
 import Radio from './Radio';
-import s from './Radio.css';
+import css from './Radio.css';
 
 /*
  * Example usage:
@@ -27,16 +27,15 @@ export default class RadioGroup {
       className,
       onChange,
       children,
-      giant,
       name,
     } = this.props;
     return (
-      <div className={[giant ? s.giant : s.group, className].join(' ')}>
+      <div className={[css.group, className].join(' ')}>
         {children && children(props =>
-          <Radio name={name}
-                 selectedValue={value}
-                 giant={giant}
-                 onChange={onChange} {...props} />
+          <Radio
+            name={name}
+            selectedValue={value}
+            onChange={onChange} {...props} />
         )}
       </div>
     );

--- a/styleguide/sections/Forms.js
+++ b/styleguide/sections/Forms.js
@@ -181,21 +181,6 @@ export default class FormSection extends Component {
         </RadioGroup>
         <p>You selected {this.state.radioVal}</p>
 
-        <h3>Giant radio buttons</h3>
-        <RadioGroup name="example"
-                    giant
-                    onChange={this.handleRadio}
-                    value={this.state.radioVal}>
-          {radio => (
-            <span>
-              <span>
-                {radio({value: 'Normal', icon: 'asap'})}
-                {radio({value: 'Decaf', icon: 'cross'})}
-              </span>
-            </span>
-          )}
-        </RadioGroup>
-
         <h3>Checkbox</h3>
         <p><Checkbox label="Checkbox" onChange={this.handleCheckbox}/> value is {this.state.checkbox ? 'checked' : 'not checked'}.</p>
 


### PR DESCRIPTION
## Generic RadioGroup and Radio components

`RadioGroup` and `Radio` components have been simplified back down to only really care about the selection logic. So as not to break usage across the board, default styles have been added so they both function and appear exactly the same as they did before the addition of the `giant` alternative.

CSS has been switched out to allow easy overriding of the default styles: instead of styles being attached to element through a `className` that is untouchable from the outside, you can now supply a parent `className` and attaches the style to that.

To create the giant radio buttons, we can compose a new component which uses the following styles:

```css
.giantRadio label {...}
.giantRadio input {...}
.giantRadio input + label {...}
```

etc.

## What does Radio render?

Instead of having bespoke logic for the DOM structure that `Radio` renders, it now only renders `children` or it's given `value`. This means wherever we render the `RadioGroup`, we specify the children on an as need basis. This means `GiantRadio` can be composed (and styled) separately.

## Discuss

1. Compose the giant `RadioGroup`/`Radio` components inside loggins or topnotes?