### PR TITLE
Radio: not wrap children/value in object

### DIFF
--- a/components/RadioGroup/Radio.js
+++ b/components/RadioGroup/Radio.js
@@ -30,9 +30,7 @@ export default class Radio {
                value={value}
                onChange={() => onChange(this.props.value)} />
         <label htmlFor={id}>
-          {children ? (
-            {children}
-          ) : {value}}
+          {children ? children : value}
         </label>
       </span>
     );


### PR DESCRIPTION
Caused a fragment-related error in React as it was trying to render a keyed object.