### PR TITLE
Radio buttons no longer force their label to be capitalised

### DIFF
--- a/components/RadioGroup/Radio.css
+++ b/components/RadioGroup/Radio.css
@@ -24,7 +24,6 @@
   user-select: none;
   position: relative;
   display: inline-block;
-  text-transform: capitalize;
   transition: all 200ms var(--easeinoutback);
   padding-left: calc(var(--baseRadioSize) + 0.5em);
 }


### PR DESCRIPTION
As per https://github.com/PactCoffee/topnotes/pull/121#discussion_r42857814