### PR TITLE
Pod icons for long & short; fix MaskedFormInput

### DIFF
--- a/components/Icon/Icon.css
+++ b/components/Icon/Icon.css
@@ -33,6 +33,8 @@
 .plus,
 .heart,
 .pod,
+.pod_long,
+.pod_short,
 .card,
 .asap {
   fill: transparent;

--- a/components/Icon/icons.js
+++ b/components/Icon/icons.js
@@ -50,14 +50,16 @@ export default {
   facebook: cleanupSvg(require('./icons/facebook.svg')),
   instagram: cleanupSvg(require('./icons/instagram.svg')),
 
-  pod: cleanupSvg(require('./icons/pod.svg')),
   anDrip: cleanupSvg(require('./icons/drip.svg')),
+  aeropressFilter: cleanupSvg(require('./icons/aeropressFilter.svg')),
+
+  pod: cleanupSvg(require('./icons/pod.svg')),
+  pod_long: cleanupSvg(require('./icons/pod.svg')),
+  pod_short: cleanupSvg(require('./icons/pod.svg')),
   drip: cleanupSvg(require('./icons/dripper.svg')),
   espresso: cleanupSvg(require('./icons/espresso.svg')),
   stovetop: cleanupSvg(require('./icons/stovetop.svg')),
   aeropress: cleanupSvg(require('./icons/aeropress.svg')),
   cafetiere: cleanupSvg(require('./icons/cafetiere.svg')),
   wholebean: cleanupSvg(require('./icons/wholebean.svg')),
-  aeropressFilter: cleanupSvg(require('./icons/aeropressFilter.svg')),
-
 };

--- a/components/MaskedFormInput/MaskedFormInput.js
+++ b/components/MaskedFormInput/MaskedFormInput.js
@@ -9,6 +9,7 @@ export default class MaskedFormInput extends Component {
   constructor(props) {
     super(props);
 
+    this.handleChange = this.handleChange.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
 
@@ -30,11 +31,16 @@ export default class MaskedFormInput extends Component {
     });
   }
 
+  handleChange(e) {
+    const {onChange} = this.props;
+    const {value} = e.target;
+    onChange(value);
+  }
+
   render() {
     const {
       placeholder,
       borderless,
-      onChange,
       error,
       value,
       label,
@@ -68,7 +74,7 @@ export default class MaskedFormInput extends Component {
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           className={css.input}
-          onChange={onChange}
+          onChange={this.handleChange}
           value={value}
           id={id}
           type={type}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pactcoffee/loggins",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "description": "Pact's component library",
   "main": "components/index.js",
   "license": "MIT",


### PR DESCRIPTION
Adds pod icons for `pod_long` and `pod_short` (identical but could change in future). Means we can use them easily with `Icon.js` when mapping to our brew types.