### PR TITLE
Temporary fix for MaskedInput

### DIFF
--- a/components/MaskedFormInput/MaskedFormInput.js
+++ b/components/MaskedFormInput/MaskedFormInput.js
@@ -20,15 +20,17 @@ export default class MaskedFormInput extends Component {
   }
 
   handleFocus() {
+    const {onFocus} = this.props;
     this.setState({
       focus: true,
-    });
+    }, () => onFocus && onFocus());
   }
 
   handleBlur() {
+    const {onBlur} = this.props;
     this.setState({
       focus: false,
-    });
+    }, () => onBlur && onBlur());
   }
 
   handleChange(e) {

--- a/components/MaskedFormInput/MaskedFormInput.js
+++ b/components/MaskedFormInput/MaskedFormInput.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import {uniqueId} from 'lodash';
 
-import MaskedInput from 'react-maskedinput';
+import MaskedInput from 'react-maskedinput/src/index.jsx';
 
 import css from '../FormInput/FormInput.css';
 

--- a/components/MaskedFormInput/MaskedFormInput.js
+++ b/components/MaskedFormInput/MaskedFormInput.js
@@ -94,6 +94,8 @@ export default class MaskedFormInput extends Component {
 MaskedFormInput.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
   label: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   pattern: PropTypes.string.isRequired,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^3.10.0",
     "moment": "^2.10.3",
     "react-day-picker": "^1.1.0",
-    "react-maskedinput": "^2.0.0",
+    "react-maskedinput": "iest/react-maskedinput",
     "react-motion": "^0.3.0",
     "react-router": "^1.0.0-rc1",
     "react-slider": "^0.5.1",


### PR DESCRIPTION
The version of `react-maskedinput` we're using is an uncontrolled component: that is — we can't change the value of the input (which we need to do in some cases).

So I forked it and [made a simple fix](https://github.com/iest/react-maskedinput/commit/555ed8451d7def085dd8e9966898ac98779916e0).

This also passes through `onBlur` and `onFocus` callbacks to MaskedInput.