### PR TITLE
White hollow buttons are now readable on hover

### DIFF
--- a/components/Btn/Btn.css
+++ b/components/Btn/Btn.css
@@ -111,6 +111,20 @@
   background: color(var(--color-secondary) l(- 5%));
 }
 
+.white.hollow {
+  box-shadow: inset 0 0 0 0.1em var(--color-white);
+  color: var(--color-white);
+}
+.white.hollow:hover {
+  box-shadow: inset 0 0 0 0.1em var(--color-white);
+  background: color(var(--color-white) a(50%));
+  color: var(--color-white);
+}
+.white.hollow:active {
+  box-shadow: inset 0 0 0 0.1em var(--color-white);
+  background: color(var(--color-white) a(70%));
+}
+
 .clean {
   background: transparent;
   border-color: transparent;
@@ -147,18 +161,6 @@
 }
 .danger.clean:active {
   color: color(var(--color-error) a(70%));
-}
-
-.white.hollow {
-  box-shadow: inset 0 0 0 0.12em var(--color-white);
-  color: var(--color-white);
-}
-.white.hollow:hover {
-  background: var(--color-white);
-  color: var(--color-white);
-}
-.white.hollow:active {
-  background: color(var(--color-white) l(- 5%));
 }
 
 .fullWidth {

--- a/styleguide/sections/Buttons.js
+++ b/styleguide/sections/Buttons.js
@@ -28,6 +28,7 @@ export default class BtnSection extends Component {
 
         <Btn className={[m.mbs, m.mrs].join(' ')} variant="hollow">Hollow</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} type="secondary" variant="hollow">Secondary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} type="white" variant="hollow">white</Btn>
 
         <h4>Clean</h4>
 


### PR DESCRIPTION
# Before

![btn-white-hollow-before](https://cloud.githubusercontent.com/assets/2162181/11624606/ec6c1712-9ccc-11e5-82ef-1f2f330be398.gif)

# After

![btn-white-hollow-after](https://cloud.githubusercontent.com/assets/2162181/11624610/efeb33a0-9ccc-11e5-82af-fc098f06eb08.gif)
