### PR TITLE
Btn refactor

### DIFF
--- a/components/Btn/Btn.css
+++ b/components/Btn/Btn.css
@@ -37,16 +37,6 @@
   background: color(var(--color-primary) l(- 2%));
 }
 
-.secondary {
-  background: var(--color-secondary);
-}
-.secondary:hover {
-  background: color(var(--color-secondary) l(+ 5%));
-}
-.secondary:active {
-  background: color(var(--color-secondary) l(- 5%));
-}
-
 .danger {
   background: var(--color-error);
 }
@@ -91,18 +81,6 @@
 }
 .primary.hollow:active {
   background: color(var(--color-primary) l(- 5%));
-}
-
-.secondary.hollow {
-  box-shadow: inset 0 0 0 0.1em var(--color-secondary);
-  color: var(--color-secondary);
-}
-.secondary.hollow:hover {
-  background: var(--color-secondary);
-  color: var(--color-white);
-}
-.secondary.hollow:active {
-  background: color(var(--color-secondary) l(- 5%));
 }
 
 .danger.hollow {
@@ -157,16 +135,6 @@
 }
 .primary.text:active {
   color: color(var(--color-primary) a(70%));
-}
-
-.secondary.text {
-  color: var(--color-secondary);
-}
-.secondary.text:hover {
-  color: color(var(--color-secondary) l(- 10%));
-}
-.secondary.text:active {
-  color: color(var(--color-secondary) a(70%));
 }
 
 .danger.text {

--- a/components/Btn/Btn.css
+++ b/components/Btn/Btn.css
@@ -25,7 +25,7 @@
   cursor: not-allowed;
 }
 
-/* Types */
+/* Contexts */
 .primary {
   background: var(--color-primary);
   color: var(--color-white);
@@ -57,7 +57,18 @@
   background: color(var(--color-error) l(- 5%));
 }
 
-/* Variants */
+.whiteOut {
+  background: var(--color-white);
+  color: var(--color-text);
+}
+.whiteOut:hover {
+  background: color(var(--color-white) a(10%));
+}
+.whiteOut:active {
+  background: color(var(--color-white) a(20%));
+}
+
+/* Styles */
 .hollow {
   background: transparent;
   box-shadow: inset 0 0 0 0.1em var(--color-action);
@@ -94,65 +105,87 @@
   background: color(var(--color-secondary) l(- 5%));
 }
 
-.white.hollow {
+.danger.hollow {
+  box-shadow: inset 0 0 0 0.1em var(--color-error);
+  color: var(--color-error);
+}
+.danger.hollow:hover {
+  background: var(--color-error);
+  color: var(--color-white);
+}
+.danger.hollow:active {
+  background: color(var(--color-error) l(- 5%));
+}
+
+.whiteOut.hollow {
   box-shadow: inset 0 0 0 0.1em var(--color-white);
   color: var(--color-white);
 }
-.white.hollow:hover {
+.whiteOut.hollow:hover {
   box-shadow: inset 0 0 0 0.1em var(--color-white);
   background: color(var(--color-white) a(50%));
   color: var(--color-white);
 }
-.white.hollow:active {
+.whiteOut.hollow:active {
   box-shadow: inset 0 0 0 0.1em var(--color-white);
   background: color(var(--color-white) a(70%));
 }
 
-.clean {
+.text {
   background: transparent;
   border-color: transparent;
   color: var(--color-action);
 }
-.clean:hover {
+.text:hover {
   background: transparent;
   color: color(var(--color-action) w(+ 50%));
 }
-.clean:active {
+.text:active {
   background: transparent;
   color: color(var(--color-action) a(70%));
 }
-.clean.active {
+.text.active {
   background-color: var(--color-primary);
   color: var(--color-white);
 }
 
-.primary.clean {
+.primary.text {
   color: var(--color-primary);
 }
-.primary.clean:hover {
+.primary.text:hover {
   color: color(var(--color-primary) l(- 10%));
 }
-.primary.clean:active {
+.primary.text:active {
   color: color(var(--color-primary) a(70%));
 }
 
-.danger.clean {
+.secondary.text {
+  color: var(--color-secondary);
+}
+.secondary.text:hover {
+  color: color(var(--color-secondary) l(- 10%));
+}
+.secondary.text:active {
+  color: color(var(--color-secondary) a(70%));
+}
+
+.danger.text {
   color: var(--color-error);
 }
-.danger.clean:hover {
+.danger.text:hover {
   color: color(var(--color-error) l(- 10%));
 }
-.danger.clean:active {
+.danger.text:active {
   color: color(var(--color-error) a(70%));
 }
 
-.white.clean {
+.whiteOut.text {
   color: var(--color-white);
 }
-.white.clean:hover {
+.whiteOut.text:hover {
   color: color(var(--color-white) l(- 10%));
 }
-.white.clean:active {
+.whiteOut.text:active {
   color: color(var(--color-white) a(70%));
 }
 
@@ -172,11 +205,11 @@
 
 /* Links */
 .link {
-  composes: root clean;
+  composes: root text;
 }
 .primaryLink {
-  composes: root clean primary;
+  composes: root text primary;
 }
 .linkWhite {
-  composes: root clean white;
+  composes: root text whiteOut;
 }

--- a/components/Btn/Btn.css
+++ b/components/Btn/Btn.css
@@ -3,7 +3,7 @@
   font-family: var(--font-brandon);
   font-size: 1em;
   font-weight: 400;
-  padding: 0.5em 1em;
+  padding: 0.5em 1.25em;
   border: none;
   border-radius: 4px;
   color: rgba(255, 255, 255, 0.9);
@@ -14,7 +14,7 @@
   text-decoration: none;
 }
 .root:hover {
-  background: color(var(--color-action) l(+ 1%));
+  background: color(var(--color-action) l(+ 5%));
 }
 .root:active {
   background: color(var(--color-action) l(- 5%));
@@ -31,10 +31,10 @@
   color: var(--color-white);
 }
 .primary:hover {
-  background: color(var(--color-primary) l(+ 2%));
+  background: color(var(--color-primary) l(+ 5%));
 }
 .primary:active {
-  background: color(var(--color-primary) l(- 2%));
+  background: color(var(--color-primary) l(- 5%));
 }
 
 .danger {
@@ -58,8 +58,39 @@
   background: color(var(--color-white) a(20%));
 }
 
-/* Styles */
+.subtle {
+  background: var(--color-muted);
+}
+.subtle:hover {
+  background: color(var(--color-muted) l(+ 5%));
+}
+.subtle:active {
+  background: color(var(--color-muted) l(- 5%));
+}
+
+/* Variants */
+.cta {
+  font-family: var(--font-brandon);
+  font-size: 0.9em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.condensed {
+  composes: cta;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+}
+
+.tiny {
+  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 0.65em;
+  padding: 0.35em 0.65em;
+}
+
 .hollow {
+  composes: cta;
   background: transparent;
   box-shadow: inset 0 0 0 0.1em var(--color-action);
   color: var(--color-action);
@@ -77,7 +108,8 @@
   color: var(--color-primary);
 }
 .primary.hollow:hover {
-  background: color(var(--color-primary) a(20%));
+  background: var(--color-primary);
+  color: var(--color-white);
 }
 .primary.hollow:active {
   background: color(var(--color-primary) l(- 5%));
@@ -107,6 +139,18 @@
 .whiteOut.hollow:active {
   box-shadow: inset 0 0 0 0.1em var(--color-white);
   background: color(var(--color-white) a(70%));
+}
+
+.subtle.hollow {
+  box-shadow: inset 0 0 0 0.1em var(--color-muted);
+  color: var(--color-muted);
+}
+.subtle.hollow:hover {
+  background: var(--color-muted);
+  color: var(--color-white);
+}
+.subtle.hollow:active {
+  background: color(var(--color-muted) l(- 5%));
 }
 
 .text {
@@ -157,27 +201,18 @@
   color: color(var(--color-white) a(70%));
 }
 
+.subtle.text {
+  color: var(--color-muted);
+}
+.subtle.text:hover {
+  color: color(var(--color-muted) l(- 10%));
+}
+.subtle.text:active {
+  color: color(var(--color-muted) a(70%));
+}
+
 /* Modifiers */
 .fullWidth {
   width: 100%;
   text-align: center;
-}
-
-.cta {
-  font-family: var(--font-brandon);
-  font-size: 0.9em;
-  text-transform: uppercase;
-  font-weight: 600;
-  padding: .84rem 3.1rem;
-}
-
-/* Links */
-.link {
-  composes: root text;
-}
-.primaryLink {
-  composes: root text primary;
-}
-.linkWhite {
-  composes: root text whiteOut;
 }

--- a/components/Btn/Btn.js
+++ b/components/Btn/Btn.js
@@ -43,13 +43,16 @@ Btn.propTypes = {
   fullWidth: PropTypes.bool,
   context: PropTypes.oneOf([
     'primary',
-    'secondary',
     'danger',
     'whiteOut',
+    'subtle',
   ]),
   variant: PropTypes.oneOf([
+    'condensed',
+    'cta',
     'hollow',
     'text',
+    'tiny',
   ]),
   onClick: PropTypes.func,
 };

--- a/components/Btn/Btn.js
+++ b/components/Btn/Btn.js
@@ -1,38 +1,35 @@
-import styles from './Btn.css';
-
 import React, { Component, PropTypes } from 'react';
+
+import css from './Btn.css';
 
 export default class Btn extends Component {
   render() {
     const {
-      href,
-      type,
-      variant,
-      fullWidth,
-      className,
-      disabled,
-      onClick,
-      children,
       active,
-      cta,
+      children,
+      className,
+      fullWidth,
+      context,
+      variant,
+      onClick,
+      ...remainingProps,
     } = this.props;
 
     const classNames = [
-      styles.root,
-      styles[type],
-      styles[variant],
-      variant ? styles[variant] : null,
-      fullWidth ? styles.fullWidth : null,
-      active ? styles.active : null,
-      cta ? styles.cta : null,
+      css.root,
+      variant ? css[variant] : null,
+      context ? css[context] : null,
+      fullWidth ? css.fullWidth : null,
+      active ? css.active : null,
       className,
     ].join(' ');
 
     return (
-      href ?
-      <a href={href} className={classNames}>{children}</a>
-      :
-      <button onClick={onClick} disabled={disabled} className={classNames}>
+      <button
+        className={classNames}
+        onClick={onClick}
+        {...remainingProps}
+      >
         {children}
       </button>
     );
@@ -40,24 +37,19 @@ export default class Btn extends Component {
 }
 
 Btn.propTypes = {
-  type: PropTypes.oneOf([
+  active: PropTypes.bool,
+  children: PropTypes.any,
+  className: PropTypes.string,
+  fullWidth: PropTypes.bool,
+  context: PropTypes.oneOf([
     'primary',
     'secondary',
     'danger',
-    'white',
+    'whiteOut',
   ]),
   variant: PropTypes.oneOf([
     'hollow',
-    'clean',
+    'text',
   ]),
-
   onClick: PropTypes.func,
-  href: PropTypes.string,
-  disabled: PropTypes.bool,
-
-  children: PropTypes.any,
-  fullWidth: PropTypes.bool,
-  className: PropTypes.string,
-  active: PropTypes.bool,
-  cta: PropTypes.bool,
 };

--- a/components/__tests__/Btn-test.js
+++ b/components/__tests__/Btn-test.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { findDOMNode } from 'react-dom';
+import React, { findDOMNode } from 'react';
 import { renderIntoDocument, Simulate } from 'react/lib/ReactTestUtils';
 
 import Btn from '../Btn/Btn.js';
@@ -18,15 +17,8 @@ describe('Btn', () => {
     assert.ok(node.className.match(/\bTESTMCTESTERSON\b/));
   });
 
-  it(`Doesn't pass through all props it's given`, () => {
-    const node = findDOMNode(renderIntoDocument(
-      <Btn data-someRandoAttribute="derp"/>
-    ));
-    assert.equal(node.getAttribute('data-someRandoAttribute'), null);
-  });
-
   it('Correctly applies the className for the context', () => {
-    ['primary', 'secondary', 'danger', 'whiteOut'].forEach(context => {
+    ['primary', 'danger', 'whiteOut', 'subtle'].forEach(context => {
       const node = findDOMNode(renderIntoDocument(
         <Btn context={context}/>
       ));
@@ -35,7 +27,7 @@ describe('Btn', () => {
   });
 
   it('Correctly applies the className for the variant', () => {
-    ['hollow', 'text'].forEach(variant => {
+    ['condensed', 'cta', 'hollow', 'text', 'tiny'].forEach(variant => {
       const node = findDOMNode(renderIntoDocument(
         <Btn variant={variant}/>
       ));

--- a/components/__tests__/Btn-test.js
+++ b/components/__tests__/Btn-test.js
@@ -1,4 +1,5 @@
-import React, { findDOMNode } from 'react';
+import React from 'react';
+import { findDOMNode } from 'react-dom';
 import { renderIntoDocument, Simulate } from 'react/lib/ReactTestUtils';
 
 import Btn from '../Btn/Btn.js';
@@ -8,13 +9,6 @@ describe('Btn', () => {
   it('Should render a button', () => {
     const node = findDOMNode(renderIntoDocument(<Btn>btn</Btn>));
     assert.equal(node.nodeName, 'BUTTON');
-  });
-
-  it('Should output an anchor when passed an href', () => {
-    const node = findDOMNode(renderIntoDocument(
-      <Btn href="#">A link, really. Not a button at all.</Btn>
-    ));
-    assert.equal(node.nodeName, 'A');
   });
 
   it('Passes through the className to the actual DOM element', () => {
@@ -31,17 +25,17 @@ describe('Btn', () => {
     assert.equal(node.getAttribute('data-someRandoAttribute'), null);
   });
 
-  it('Correctly applies the className for the type', () => {
-    ['primary', 'secondary', 'danger', 'white'].forEach(type => {
+  it('Correctly applies the className for the context', () => {
+    ['primary', 'secondary', 'danger', 'whiteOut'].forEach(context => {
       const node = findDOMNode(renderIntoDocument(
-        <Btn type={type}/>
+        <Btn context={context}/>
       ));
-      assert.ok(node.className.match(new RegExp(classNames[type])));
+      assert.ok(node.className.match(new RegExp(classNames[context])));
     });
   });
 
   it('Correctly applies the className for the variant', () => {
-    ['hollow', 'clean'].forEach(variant => {
+    ['hollow', 'text'].forEach(variant => {
       const node = findDOMNode(renderIntoDocument(
         <Btn variant={variant}/>
       ));
@@ -61,13 +55,6 @@ describe('Btn', () => {
       <Btn disabled/>
     ));
     assert.ok(node.disabled);
-  });
-
-  it(`Can't be disabled if it's an anchor with an href`, () => {
-    const node = findDOMNode(renderIntoDocument(
-      <Btn href="#" disabled/>
-    ));
-    assert.notOk(node.disabled);
   });
 
   it(`Calls the onClick function it's passed`, (done) => {

--- a/styleguide/sections/Buttons.js
+++ b/styleguide/sections/Buttons.js
@@ -27,7 +27,6 @@ export default class BtnSection extends Component {
         <h3>Contexts</h3>
         <Btn className={[m.mbs, m.mrs].join(' ')}>Default</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="primary">Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary">Secondary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="danger">Danger</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut">Whiteout</Btn>
 
@@ -37,7 +36,6 @@ export default class BtnSection extends Component {
 
         <Btn className={[m.mbs, m.mrs].join(' ')} variant="hollow">Default</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="hollow">Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary" variant="hollow">Secondary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="hollow">Danger</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="hollow">Whiteout</Btn>
 
@@ -45,20 +43,17 @@ export default class BtnSection extends Component {
 
         <Btn className={[m.mbs, m.mrs].join(' ')} variant="text">Default</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="text">Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary" variant="text">Secondary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="text">Danger</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="text">Whiteout</Btn>
 
         <h3>Disabled</h3>
         <Btn className={[m.mbs, m.mrs].join(' ')} disabled>Default</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="hollow" disabled>Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary" variant="text" disabled>Secondary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" disabled>Danger</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" disabled>Whiteout</Btn>
 
         <h3>Disabled</h3>
         <Btn className={[m.mbs, m.mrs].join(' ')} type="primary" disabled>Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="secondary" disabled>Secondary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} type="danger" disabled>Danger</Btn>
 
         <h3>With icon(s)</h3>

--- a/styleguide/sections/Buttons.js
+++ b/styleguide/sections/Buttons.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Markdown from 'matthewmueller-react-remarkable';
 
 import ScreenReadable from 'components/ScreenReadable/ScreenReadable';
 import BtnContainer from 'components/BtnContainer/BtnContainer';
@@ -16,30 +17,44 @@ export default class BtnSection extends Component {
     return (
       <Section name="Buttons" href="https://github.com/PactCoffee/loggins/blob/master/styleguide%2Fsections%2FButtons.js">
 
-        <Btn className={[m.mbs, m.mrs].join(' ')}>Standard</Btn>
+        <h2>Standard button</h2>
 
-        <h3>Types</h3>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="primary">Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="secondary">Secondary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="danger">Danger</Btn>
+        <Markdown>{`
+          The \`<Btn />\` component acts as a wrapper for a typical HTML \`<button/>\` with the addition of styles and contexts. Pass it any [valid (React style) HTML attribute](https://facebook.github.io/react/docs/tags-and-attributes.html), \`context\` or \`variant\` like so:
+        `}
+        </Markdown>
 
-        <h3>Variants</h3>
+        <h3>Contexts</h3>
+        <Btn className={[m.mbs, m.mrs].join(' ')}>Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary">Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary">Secondary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger">Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut">Whiteout</Btn>
+
+        <h3>Styles</h3>
 
         <h4>Hollow</h4>
 
-        <Btn className={[m.mbs, m.mrs].join(' ')} variant="hollow">Hollow</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="secondary" variant="hollow">Secondary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="white" variant="hollow">white</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="hollow">Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="hollow">Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary" variant="hollow">Secondary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="hollow">Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="hollow">Whiteout</Btn>
 
-        <h4>Clean</h4>
+        <h4>Text only</h4>
 
-        <Btn className={[m.mbs, m.mrs].join(' ')} variant="clean">Clean</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="primary" variant="clean">Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="text">Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="text">Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary" variant="text">Secondary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="text">Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="text">Whiteout</Btn>
 
-        <h3>CTAs</h3>
-        <Btn cta className={[m.mbs, m.mrs].join(' ')} type="primary">Primary</Btn>
-        <Btn cta className={[m.mbs, m.mrs].join(' ')} variant="hollow">Hollow</Btn>
-        <Btn cta className={[m.mbs, m.mrs].join(' ')} variant="clean">Clean</Btn>
+        <h3>Disabled</h3>
+        <Btn className={[m.mbs, m.mrs].join(' ')} disabled>Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="hollow" disabled>Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="secondary" variant="text" disabled>Secondary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" disabled>Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" disabled>Whiteout</Btn>
 
         <h3>Disabled</h3>
         <Btn className={[m.mbs, m.mrs].join(' ')} type="primary" disabled>Primary</Btn>
@@ -47,7 +62,6 @@ export default class BtnSection extends Component {
         <Btn className={[m.mbs, m.mrs].join(' ')} type="danger" disabled>Danger</Btn>
 
         <h3>With icon(s)</h3>
-
         <Btn className={[m.mbs, m.mrs].join(' ')}>
           <Icon name="heart"/>
           &nbsp;
@@ -55,7 +69,6 @@ export default class BtnSection extends Component {
           &nbsp;
           <Icon name="coffee"/>
         </Btn>
-
         <Btn className={[m.mbs, m.mrs].join(' ')} variant="hollow">
           <Icon name="asap"/>
           &nbsp;
@@ -63,8 +76,7 @@ export default class BtnSection extends Component {
           &nbsp;
           <Icon name="pin"/>
         </Btn>
-
-        <Btn className={[m.mbs, m.mrs].join(' ')} variant="clean">
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="text">
           <Icon name="play"/>
           &nbsp;
           Avec icon
@@ -83,6 +95,9 @@ export default class BtnSection extends Component {
 
         <Btn fullWidth>Full width</Btn>
 
+        <h2>Special buttons</h2>
+
+        <h3>Button container</h3>
         <BtnContainer>
           <h4>Button container</h4>
           <p>Will simply render children and impose no style by default</p>

--- a/styleguide/sections/Buttons.js
+++ b/styleguide/sections/Buttons.js
@@ -29,8 +29,17 @@ export default class BtnSection extends Component {
         <Btn className={[m.mbs, m.mrs].join(' ')} context="primary">Primary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="danger">Danger</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut">Whiteout</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="subtle">Subtle</Btn>
 
         <h3>Styles</h3>
+
+        <h4>Call to action</h4>
+
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="cta">Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="cta">Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="cta">Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="cta">Whiteout</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="subtle" variant="cta">Subtle</Btn>
 
         <h4>Hollow</h4>
 
@@ -38,6 +47,7 @@ export default class BtnSection extends Component {
         <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="hollow">Primary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="hollow">Danger</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="hollow">Whiteout</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="subtle" variant="hollow">Subtle</Btn>
 
         <h4>Text only</h4>
 
@@ -45,16 +55,30 @@ export default class BtnSection extends Component {
         <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="text">Primary</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="text">Danger</Btn>
         <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="text">Whiteout</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="subtle" variant="text">Subtle</Btn>
+
+        <h4>Condensed</h4>
+
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="condensed">Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="condensed">Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="condensed">Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="condensed">Whiteout</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="subtle" variant="condensed">Subtle</Btn>
+
+        <h4>Tiny</h4>
+
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="tiny">Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="tiny">Primary</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" variant="tiny">Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" variant="tiny">Whiteout</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} context="subtle" variant="tiny">Subtle</Btn>
 
         <h3>Disabled</h3>
         <Btn className={[m.mbs, m.mrs].join(' ')} disabled>Default</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} context="primary" variant="hollow" disabled>Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} context="danger" disabled>Danger</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} context="whiteOut" disabled>Whiteout</Btn>
-
-        <h3>Disabled</h3>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="primary" disabled>Primary</Btn>
-        <Btn className={[m.mbs, m.mrs].join(' ')} type="danger" disabled>Danger</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="cta" disabled>Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="condensed" disabled>Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="tiny" disabled>Default</Btn>
+        <Btn className={[m.mbs, m.mrs].join(' ')} variant="hollow" disabled>Default</Btn>
 
         <h3>With icon(s)</h3>
         <Btn className={[m.mbs, m.mrs].join(' ')}>


### PR DESCRIPTION
## What

Start of the button refactor as per [my initial thoughts](https://gist.github.com/rdjpalmer/ead0c09514f4177c1446).

`<Btn />` to ensure we don't use native HTML attributes, such as `type` for our own purposes. Also allows us to add *any* native HTML attributes without having to whitelist them.

1. `type` => `context`. Gives additional context to the button through styles.
2. Removed `href` prop and `<a />` support.
3. Removed `cta` prop
4. Introduce `cta`, `condensed` and `tiny` variants
5. Introduce `subtle` context

### `type` => `context`

1. `white` => `whiteOut`. Provides more context as to the purpose of the button. Also considering `reverse` as an alternative. All ears for suggestions here.

### `variant`

1. `clean` => `text`. A better description of what to expect when using this style of button.

## Preview

<img width="605" alt="screen shot 2016-01-12 at 09 19 24" src="https://cloud.githubusercontent.com/assets/2162181/12259427/a3c06d4e-b90d-11e5-859d-3dc01850f762.png">
<img width="535" alt="screen shot 2016-01-12 at 09 19 40" src="https://cloud.githubusercontent.com/assets/2162181/12259428/a3c39014-b90d-11e5-9122-fbbf0da7296c.png">

## Todo

- [x] [Agree on button styles](https://gist.github.com/rdjpalmer/ead0c09514f4177c1446#gistcomment-1662933) /cc @iest, @scott-riley 
- [x] Refactor button styles based on the above decision
- [x] Update test