### PR TITLE
Refactor checkbox to not contain own state

### DIFF
--- a/components/Checkbox/Checkbox.js
+++ b/components/Checkbox/Checkbox.js
@@ -7,36 +7,31 @@ export default class Checkbox extends Component {
   constructor(props) {
     super(props);
     this.id = `check-${Math.random() * new Date().getTime()}`;
-    this.toggleChecked = this.toggleChecked.bind(this);
-    this.state = {
-      checked: props.checked || false,
-    };
-  }
-
-  toggleChecked() {
-    this.setState(state => (
-      { checked: !state.checked }
-    ), () => this.props.onChange(this.state.checked));
   }
 
   render() {
+    const {
+      className,
+      onChange,
+      checked,
+      label,
+    } = this.props;
     const checkboxClasses = [
       s.root,
-      this.props.className,
-      this.state.checked ? s.isChecked : null,
+      className,
+      checked ? s.isChecked : null,
     ].join(' ');
 
     return (
       <span className={checkboxClasses}>
         <input
           type="checkbox"
-          checked={this.state.checked}
-          onChange={this.toggleChecked}
-          name={this.props.name}
+          checked={checked}
+          onChange={onChange}
           id={this.id}
           className={s.input}
         />
-        <label htmlFor={this.id} className={s.label}>{this.props.label}</label>
+        <label htmlFor={this.id} className={s.label}>{label}</label>
         <Icon className={s.tick} name="tick"/>
       </span>
     );
@@ -46,7 +41,6 @@ export default class Checkbox extends Component {
 Checkbox.propTypes = {
   onChange: PropTypes.func,
   checked: PropTypes.bool,
-  name: PropTypes.string,
   label: PropTypes.string,
   className: PropTypes.string,
 };

--- a/components/__tests__/Checkbox-test.js
+++ b/components/__tests__/Checkbox-test.js
@@ -57,7 +57,7 @@ describe('Checkbox', () => {
 
   it('Is checked when the checked prop is true', () => {
     const node = findDOMNode(renderIntoDocument(
-      <Checkbox checked={true}/>
+      <Checkbox onChange={() => ({})} checked={true}/>
     ));
     assert.ok(node.className.match(new RegExp(classNames.isChecked)));
   });

--- a/components/__tests__/Checkbox-test.js
+++ b/components/__tests__/Checkbox-test.js
@@ -69,11 +69,6 @@ describe('Checkbox', () => {
     assert.notOk(node.className.match(new RegExp(classNames.isChecked)));
   });
 
-  it('Accepts a name attribute and applies it to the input', () => {
-    const instance = renderIntoDocument(<Checkbox name="herp"/>);
-    assert.equal(getInputNode(instance).name, 'herp');
-  });
-
   it('Passes through the className', () => {
     const instance = renderIntoDocument(
       <Checkbox className="TEEESTTT"/>

--- a/styleguide/sections/Forms.js
+++ b/styleguide/sections/Forms.js
@@ -84,8 +84,8 @@ export default class FormSection extends Component {
     this.setState({ liked: didLike });
   }
 
-  handleCheckbox(val) {
-    this.setState({ checkbox: val });
+  handleCheckbox() {
+    this.setState({ checkbox: !this.state.checkbox });
   }
 
   handleToggle() {
@@ -192,7 +192,22 @@ export default class FormSection extends Component {
         <p>You selected {this.state.radioVal}</p>
 
         <h3>Checkbox</h3>
-        <p><Checkbox label="Checkbox" onChange={this.handleCheckbox}/> value is {this.state.checkbox ? 'checked' : 'not checked'}.</p>
+        <p>
+          <Checkbox
+            label="Checkbox"
+            checked={this.state.checkbox}
+            onChange={this.handleCheckbox}
+          /> value is {this.state.checkbox ? 'checked' : 'not checked'}.
+        </p>
+        <p>
+          <Checkbox
+            label={
+              <span>Checkbox with <strong>component</strong> label</span>
+            }
+            checked={!this.state.checkbox}
+            onChange={this.handleCheckbox}
+          /> is {!this.state.checkbox ? 'checked' : 'not checked'}.
+        </p>
 
         <h3>Slider</h3>
         <strong>Basic version:</strong>


### PR DESCRIPTION
For some reason that I can't remember, the Checkbox component was doing state syncing (which broke stuff on usage with topnotes).

Anyway, now it doesn't.