### PR TITLE
Combine FormInput & MaskedFormInput

### DIFF
--- a/components/FormInput/FormInput.js
+++ b/components/FormInput/FormInput.js
@@ -1,93 +1,11 @@
 import React, { Component, PropTypes } from 'react';
-import { uniqueId } from 'lodash/utility';
 
-import css from './FormInput.css';
+import SharedFormInput from './SharedFormInput';
 
 export default class FormInput extends Component {
-  constructor(props) {
-    super(props);
-
-    this.handleChange = this.handleChange.bind(this);
-    this.handleFocus = this.handleFocus.bind(this);
-    this.handleBlur = this.handleBlur.bind(this);
-
-    this.state = {
-      focus: false,
-      id: uniqueId('forminput'),
-    };
-  }
-
-  handleFocus() {
-    const { onFocus } = this.props;
-    this.setState({
-      focus: true,
-    }, () => onFocus && onFocus());
-  }
-
-  handleBlur() {
-    const { onBlur } = this.props;
-    this.setState({
-      focus: false,
-    }, () => onBlur && onBlur());
-  }
-
-  handleChange(e) {
-    const { onChange, transform } = this.props;
-    let { value } = e.target;
-    if (transform) {
-      value = transform(value);
-    }
-    onChange(value);
-  }
-
   render() {
-    const {
-      placeholder,
-      borderless,
-      required,
-      error,
-      value,
-      label,
-      type,
-    } = this.props;
-    const { focus, id } = this.state;
-
-    const active = value && !!value.length;
-
-    const outerCSS = [
-      css.container,
-      required ? css.required : null,
-      placeholder ? css.labelInside : css.labelOutside,
-      error ? css.containerError : null,
-      active ? css.containerActive : null,
-      focus ? css.containerFocus : null,
-      borderless ? css.borderless : null,
-    ].join(' ');
-
-    const messageCSS = [
-      css.message,
-      error ? css.messageError : null,
-    ].join(' ');
-
     return (
-      <div className={outerCSS}>
-        <label htmlFor={id} className={css.label}>
-          {label}{required ? '*' : null}
-        </label>
-        <input
-          placeholder={placeholder}
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
-          className={css.input}
-          onChange={this.handleChange}
-          value={value}
-          id={id}
-          type={type}
-        />
-        <span className={messageCSS}>
-          {this.props.error}
-        </span>
-      </div>
+      <SharedFormInput {...this.props}/>
     );
   }
 }

--- a/components/FormInput/SharedFormInput.js
+++ b/components/FormInput/SharedFormInput.js
@@ -1,0 +1,134 @@
+import React, { Component, PropTypes } from 'react';
+import { uniqueId } from 'lodash/utility';
+
+import MaskedInput from 'react-maskedinput/src/index.jsx';
+
+import css from './FormInput.css';
+
+export default class SharedFormInput extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
+
+    this.state = {
+      focus: false,
+      id: uniqueId('forminput'),
+    };
+  }
+
+  handleFocus() {
+    const { onFocus } = this.props;
+    this.setState({
+      focus: true,
+    }, () => onFocus && onFocus());
+  }
+
+  handleBlur() {
+    const { onBlur } = this.props;
+    this.setState({
+      focus: false,
+    }, () => onBlur && onBlur());
+  }
+
+  handleChange(e) {
+    const { onChange, transform } = this.props;
+    let { value } = e.target;
+    if (transform) {
+      value = transform(value);
+    }
+    onChange(value);
+  }
+
+  render() {
+    const {
+      placeholder,
+      borderless,
+      required,
+      pattern,
+      masked,
+      error,
+      value,
+      label,
+      type,
+    } = this.props;
+    const { focus, id } = this.state;
+
+    const active = value && !!value.length;
+
+    const outerCSS = [
+      css.container,
+      required ? css.required : null,
+      placeholder ? css.labelInside : css.labelOutside,
+      error ? css.containerError : null,
+      active ? css.containerActive : null,
+      focus ? css.containerFocus : null,
+      borderless ? css.borderless : null,
+    ].join(' ');
+
+    const messageCSS = [
+      css.message,
+      error ? css.messageError : null,
+    ].join(' ');
+
+    return (
+      <div className={outerCSS}>
+        <label htmlFor={id} className={css.label}>
+          {label}{required ? '*' : null}
+        </label>
+        {masked ?
+          <MaskedInput
+            onFocus={this.handleFocus}
+            onBlur={this.handleBlur}
+            className={css.input}
+            onChange={this.handleChange}
+            value={value}
+            id={id}
+            type={type}
+            pattern={pattern}
+            placeholder={placeholder}
+          />
+          :
+          <input
+            placeholder={placeholder}
+            onFocus={this.handleFocus}
+            onBlur={this.handleBlur}
+            className={css.input}
+            onChange={this.handleChange}
+            value={value}
+            id={id}
+            type={type}
+          />
+
+        }
+        <span className={messageCSS}>
+          {this.props.error}
+        </span>
+      </div>
+    );
+  }
+}
+
+SharedFormInput.propTypes = {
+  // Render a MaskedInput or not
+  masked: PropTypes.bool.isRequired,
+
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+
+  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  pattern: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+
+  transform: PropTypes.func,
+  borderless: PropTypes.bool,
+  required: PropTypes.bool,
+
+  // If set, will display underneath the input
+  error: PropTypes.string,
+};

--- a/components/MaskedFormInput/MaskedFormInput.js
+++ b/components/MaskedFormInput/MaskedFormInput.js
@@ -1,108 +1,30 @@
 import React, { Component, PropTypes } from 'react';
-import { uniqueId } from 'lodash/utility';
 
-import MaskedInput from 'react-maskedinput/src/index.jsx';
+import SharedFormInput from '../FormInput/SharedFormInput';
 
-import css from '../FormInput/FormInput.css';
-
-export default class MaskedFormInput extends Component {
-  constructor(props) {
-    super(props);
-
-    this.handleChange = this.handleChange.bind(this);
-    this.handleFocus = this.handleFocus.bind(this);
-    this.handleBlur = this.handleBlur.bind(this);
-
-    this.state = {
-      focus: false,
-      id: uniqueId('forminput'),
-    };
-  }
-
-  handleFocus() {
-    const { onFocus } = this.props;
-    this.setState({
-      focus: true,
-    }, () => onFocus && onFocus());
-  }
-
-  handleBlur() {
-    const { onBlur } = this.props;
-    this.setState({
-      focus: false,
-    }, () => onBlur && onBlur());
-  }
-
-  handleChange(e) {
-    const { onChange } = this.props;
-    const { value } = e.target;
-    onChange(value);
-  }
-
+export default class FormInput extends Component {
   render() {
-    const {
-      placeholder,
-      borderless,
-      error,
-      value,
-      label,
-      type,
-      pattern,
-    } = this.props;
-    const { focus, id } = this.state;
-
-    const active = value && !!value.length;
-
-    const outerCSS = [
-      css.container,
-      placeholder ? css.labelInside : css.labelOutside,
-      error ? css.containerError : null,
-      active ? css.containerActive : null,
-      focus ? css.containerFocus : null,
-      borderless ? css.borderless : null,
-    ].join(' ');
-
-    const messageCSS = [
-      css.message,
-      error ? css.messageError : null,
-    ].join(' ');
-
     return (
-      <div className={outerCSS}>
-        <label htmlFor={id} className={css.label}>
-          {label}
-        </label>
-        <MaskedInput
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
-          className={css.input}
-          onChange={this.handleChange}
-          value={value}
-          id={id}
-          type={type}
-          pattern={pattern}
-          placeholder={placeholder}
-        />
-        <span className={messageCSS}>
-          {this.props.error}
-        </span>
-      </div>
+      <SharedFormInput masked {...this.props}/>
     );
   }
 }
 
-MaskedFormInput.propTypes = {
-  value: PropTypes.string.isRequired,
+FormInput.propTypes = {
+
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
+
+  value: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  pattern: PropTypes.string.isRequired,
-
   placeholder: PropTypes.string,
+
+  transform: PropTypes.func,
   borderless: PropTypes.bool,
 
   // If set, will display underneath the input
   error: PropTypes.string,
+  required: PropTypes.bool,
 };

--- a/styleguide/sections/Forms.js
+++ b/styleguide/sections/Forms.js
@@ -108,22 +108,19 @@ export default class FormSection extends Component {
     this.setState({ slideVal });
   }
 
-  handleCreditCard(e) {
-    const { value } = e.target;
+  handleCreditCard(value) {
     this.setState({
       creditCard: value,
     });
   }
 
-  handleExpiryDate(e) {
-    const { value } = e.target;
+  handleExpiryDate(value) {
     this.setState({
       expiryDate: value,
     });
   }
 
-  handleCVC(e) {
-    const { value } = e.target;
+  handleCVC(value) {
     this.setState({
       cvc: value,
     });
@@ -253,6 +250,7 @@ export default class FormSection extends Component {
           onChange={this.handleExpiryDate}
           value={this.state.expiryDate}
           label="Expiry"
+          required
         />
         <br />
         <MaskedFormInput


### PR DESCRIPTION
- No more duplicated code
- MaskedFormInput now supports `required` prop

One "breaking" change is that MaskedFormInput's change handler is now called with the value itself, rather than the event from the input. This won't be a problem for us as everywhere we're using the component, we're using redux-form, which supports onChange being called with an event or value.