### PR TITLE
Not use `:link` selector on link styles

### DIFF
--- a/globals/typography.css
+++ b/globals/typography.css
@@ -43,7 +43,7 @@
   font-weight: 700;
 }
 
-.link:link {
+.link {
   text-decoration: underline;
   color: var(--color-primary);
   font-style: italic;


### PR DESCRIPTION
1. It broke the cascade for white links
2. We may want to apply a link style to something without an href

## Before

![screenshot 2016-01-28 14 13 20](https://cloud.githubusercontent.com/assets/1926464/12647431/08f902b8-c5cd-11e5-8076-f4c3bd07a9ed.png)

## After

![screenshot 2016-01-28 14 40 05](https://cloud.githubusercontent.com/assets/1926464/12647436/0b99a1b2-c5cd-11e5-9436-bf07599a019a.png)
