### PR TITLE
PhotoBlocks now have a fallback background

### DIFF
--- a/components/Blocks/PhotoHero.css
+++ b/components/Blocks/PhotoHero.css
@@ -13,6 +13,7 @@
   height: 100%;
   display: block;
   position: absolute;
+  background: rgba(0,0,0,0.5);
   background: linear-gradient(to top, rgba(0,0,0,0.66), rgba(0,0,0,0.33));
 }
 


### PR DESCRIPTION
Browsers that don’t support CSS gradients but support rgba will fall back to a flat background:
![image](https://cloud.githubusercontent.com/assets/2436826/12724425/d4c53e80-c905-11e5-993b-f2191a995c4b.png)
