### PR TITLE
White Progress bar

### DIFF
--- a/components/Progress/Progress.css
+++ b/components/Progress/Progress.css
@@ -12,7 +12,6 @@
   max-width: 100%;
   background: var(--color-grey);
   border-radius: 1em;
-  transition: all 100ms linear;
 }
 
 .low {

--- a/components/Progress/Progress.css
+++ b/components/Progress/Progress.css
@@ -11,6 +11,7 @@
   height: 100%;
   max-width: 100%;
   background: var(--color-grey);
+  border-radius: 1em;
   transition: all 100ms linear;
 }
 
@@ -26,4 +27,11 @@
   background: var(--color-green);
 }
 
-
+/* White variant */
+.white.root {
+  background: rgba(255, 255, 255, 0.2);
+  box-shadow: inset 0 0 0 1px white;
+}
+.white .bar {
+  background: white;
+}

--- a/components/Progress/Progress.js
+++ b/components/Progress/Progress.js
@@ -31,10 +31,11 @@ export default class Progress extends Component {
   }
 
   render() {
+    const white = this.props.white;
     const width = (this.props.value / (this.props.max - this.props.min)) * 100;
 
     return (
-      <div className={styles.root}>
+      <div className={[styles.root, white && styles.white].join(' ')}>
         <div
           className={[styles.bar, this.getStyles(width)].join(' ')}
           style={{ width: `${width}%` }}
@@ -49,4 +50,5 @@ Progress.propTypes = {
   max: PropTypes.number.isRequired,
   value: PropTypes.number.isRequired,
   hueChange: PropTypes.bool,
+  white: PropTypes.bool,
 };

--- a/styleguide/sections/Forms.js
+++ b/styleguide/sections/Forms.js
@@ -18,6 +18,7 @@ import FieldGroup from 'components/Form/FieldGroup';
 import Toggle from 'components/Toggle/Toggle';
 import Slider from 'components/Slider/Slider';
 import * as m from 'globals/modifiers.css';
+import Panel from 'components/Panel/Panel';
 import Field from 'components/Form/Field';
 import Btn from 'components/Btn/Btn';
 
@@ -342,6 +343,12 @@ export default class FormSection extends Component {
         <Progress min={0} max={100} value={25}/>
         <p>Changing the value will animate the bar. <button onClick={this.handleProgressChange}>Change value</button></p>
         <Progress min={0} max={100} hueChange value={this.state.progressVal}/>
+
+        <p>Also there's a white version for use on non-white backgrounds:</p>
+        <Panel type="success">
+          <Progress min={0} max={100} white value={this.state.progressVal}/>
+        </Panel>
+        <br/>
       </Section>
     );
   }


### PR DESCRIPTION
![screenshot 2016-02-17 15 07 40](https://cloud.githubusercontent.com/assets/1926464/13113718/346622b2-d588-11e5-983d-0b77d3ed16e2.png)

**Also removes the CSS animation** — this is so we can animate with react-motion instead.

We're not currently using Progress anywhere else in the app, so not an issue.

For use on the Crowdcube homepage work.