### PR TITLE
SharedFormInput now supports a placeholder with the label outside variant

### DIFF
--- a/components/FormInput/SharedFormInput.js
+++ b/components/FormInput/SharedFormInput.js
@@ -60,21 +60,36 @@ export default class SharedFormInput extends Component {
       error,
       value,
       label,
+      labelOutside,
       ...remainingProps,
     } = this.props;
+
     const { focus, id } = this.state;
 
-    const active = value && !!value.length;
-    const isInsideVariant = !!placeholder;
+    const hasValue = value && value.length > 0;
+    const isOutsideVariant = labelOutside || !placeholder;
+    const labelIsOutside = labelOutside || (hasValue && !placeholder);
 
     const outerCSS = [
       css.container,
-      required ? css.required : null,
-      isInsideVariant ? css.labelInside : css.labelOutside,
-      error ? css.error : null,
-      active ? css.active : null,
-      focus ? css.focus : null,
-      borderless ? css.borderless : null,
+      isOutsideVariant
+        ? css.labelOutside
+        : css.labelInside,
+      labelIsOutside
+        ? css.active
+        : null,
+      required
+        ? css.required
+        : null,
+      error
+        ? css.error
+        : null,
+      focus
+        ? css.focus
+        : null,
+      borderless
+        ? css.borderless
+        : null,
     ].join(' ');
 
     const messageCSS = [
@@ -139,7 +154,12 @@ SharedFormInput.propTypes = {
   transform: PropTypes.func,
   borderless: PropTypes.bool,
   required: PropTypes.bool,
+  labelOutside: PropTypes.bool,
 
   // If set, will display underneath the input
   error: PropTypes.string,
+};
+
+SharedFormInput.defaultProps = {
+  labelOutside: false,
 };

--- a/styleguide/sections/Forms.js
+++ b/styleguide/sections/Forms.js
@@ -274,7 +274,15 @@ export default class FormSection extends Component {
         />
         <FormInput
           type="text"
-          placeho
+          placeholder="Adding a placeholder removes the animation"
+          labelOutside
+          onChange={this.handleTextChange}
+          value={this.state.text}
+          error={this.state.error}
+          label="With placeholder"
+        />
+        <FormInput
+          type="text"
           onChange={this.handleTextChange}
           value={this.state.lolText}
           error={this.state.error}


### PR DESCRIPTION
## What

Allows the "label outside" variant to have a placeholder without breaking current usage

## Preview

<img width="967" alt="screen shot 2016-03-02 at 10 28 29" src="https://cloud.githubusercontent.com/assets/2162181/13457723/89bff650-e061-11e5-88a9-fd9b969d3435.png">
