### PR TITLE
Changed ID attribute on Stripe icon

### DIFF
--- a/components/Icon/icons/stripe.svg
+++ b/components/Icon/icons/stripe.svg
@@ -6,7 +6,7 @@
     <defs></defs>
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" opacity="0.75">
         <g id="Trust-Symbol" transform="translate(-51.000000, -32.000000)" fill="#000000">
-            <g id="Stripe">
+            <g id="powered_by_stripe">
                 <g transform="translate(51.000000, 32.000000)">
                     <g id="Group">
                         <path d="M113,26 L6,26 C2.686,26 0,23.314 0,20 L0,6 C0,2.686 2.686,0 6,0 L113,0 C116.314,0 119,2.686 119,6 L119,20 C119,23.314 116.314,26 113,26 Z M118,6 C118,3.239 115.761,1 113,1 L6,1 C3.239,1 1,3.239 1,6 L1,20 C1,22.761 3.239,25 6,25 L113,25 C115.761,25 118,22.761 118,20 L118,6 Z" id="Shape"></path>


### PR DESCRIPTION
The ID on the Stripe SVG was 'Stripe', which meant that `window.stripe` wasn't available for Stripe's UI.